### PR TITLE
repo: add `repository` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
     "publisher": "vince-fugnitto",
     "description": "",
     "version": "0.0.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/vince-fugnitto/vscode-extension-mode.git"
+    },
     "engines": {
         "vscode": "^1.46.0"
     },


### PR DESCRIPTION
**Description**

The commit adds the `repository` field in the `package.json` to declare the git repository url, and resolve the warning we obtain when performing a package (`vsce package`).

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>