### PR TITLE
ext: add `echoMode` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,15 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:vscode-extension-mode.helloWorld"
+        "onCommand:vscode-extension-mode.echoMode"
     ],
     "main": "./out/extension.js",
     "contributes": {
         "commands": [
             {
-                "command": "vscode-extension-mode.helloWorld",
-                "title": "Hello World"
+                "command": "vscode-extension-mode.echoMode",
+                "category": "Test",
+                "title": "Echo Extension Mode"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,27 +1,10 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-
-    // Use the console to output diagnostic information (console.log) and errors (console.error)
-    // This line of code will only be executed once when your extension is activated
-    console.log('Congratulations, your extension "vscode-extension-mode" is now active!');
-
-    // The command has been defined in the package.json file
-    // Now provide the implementation of the command with registerCommand
-    // The commandId parameter must match the command field in package.json
-    let disposable = vscode.commands.registerCommand('vscode-extension-mode.helloWorld', () => {
-        // The code you place here will be executed every time your command is executed
-
-        // Display a message box to the user
-        vscode.window.showInformationMessage('Hello World from vscode-extension-mode!');
+    let disposable = vscode.commands.registerCommand('vscode-extension-mode.echoMode', () => {
+        vscode.window.showInformationMessage(`'ExtensionMode' is ${context.extensionMode}`);
     });
-
     context.subscriptions.push(disposable);
 }
 
-// this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }


### PR DESCRIPTION
**Description**

The commit adds the base functionality for the `echoMode` command which is used to print out the current `ExtensionMode` of the extension using a notification making it easy for test purposes.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>