### PR TITLE
ext: update message to use name of enum

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
     let disposable = vscode.commands.registerCommand('vscode-extension-mode.echoMode', () => {
-        vscode.window.showInformationMessage(`'ExtensionMode' is ${context.extensionMode}`);
+        const mode = vscode.ExtensionMode[context.extensionMode];
+        vscode.window.showInformationMessage(`'ExtensionMode' is '${mode}'`);
     });
     context.subscriptions.push(disposable);
 }


### PR DESCRIPTION
**Description**

The commit updates the message to use the name value of the enum, and not it's value (ex: 1 is 'production').

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>